### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 ##################################################
 
-Influxdb	   KEYWORD1
-dbMeasurement		     KEYWORD1
-DB_RESPOND 	 KEYWORD1
+Influxdb	KEYWORD1
+dbMeasurement	KEYWORD1
+DB_RESPOND	KEYWORD1
 
 ##################################################
 # Methods and Functions (KEYWORD2)
 ##################################################
 
-addField 	  KEYWORD2
-addTag	 	  KEYWORD2
-empty	 	    KEYWORD2
-opendb	 	  KEYWORD2
-write	 	    KEYWORD2
-query	 	    KEYWORD2
+addField	KEYWORD2
+addTag	KEYWORD2
+empty	KEYWORD2
+opendb	KEYWORD2
+write	KEYWORD2
+query	KEYWORD2
 postString	KEYWORD2
-response    KEYWORD2
+response	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords