### PR TITLE
added empty constructor 

### DIFF
--- a/ESPinfluxdb.cpp
+++ b/ESPinfluxdb.cpp
@@ -11,9 +11,24 @@
 #define _DEBUG
 #endif
 
+Influxdb::Influxdb()
+{
+        // empty constructor so that host and port can be initialized later
+}
+
 Influxdb::Influxdb(const char *host, uint16_t port) {
         _port = String(port);
         _host = String(host);
+}
+
+void Influxdb::setHost(const char *host)
+{
+        _host = String(host);
+}
+
+void Influxdb::setPort(uint16_t port)
+{
+        _port = String(port);
 }
 
 DB_RESPONSE Influxdb::opendb(String db, String user, String password) {

--- a/ESPinfluxdb.h
+++ b/ESPinfluxdb.h
@@ -40,7 +40,11 @@ String _tag;
 class Influxdb
 {
 public:
+Influxdb();
 Influxdb(const char* host, uint16_t port);
+
+void setHost(const char* host);
+void setPort(uint16_t port);
 
 DB_RESPONSE opendb(String db);
 DB_RESPONSE opendb(String db, String user, String password);


### PR DESCRIPTION
...so that the class can be initialized after thee configuration details are known. This is helpful when you need to configure your InfluxDB after the code is compiled and written to the ESP. I'm doing this for example here: https://github.com/rudelm/ESP8266-Sensors-InfluxDB/blob/master/ManagedWifiDhtInfluxDB/ManagedWifiDhtInfluxDB.ino